### PR TITLE
fix memory table background colors (dark->light)

### DIFF
--- a/src/main/frontend/css/themes/venus.css
+++ b/src/main/frontend/css/themes/venus.css
@@ -161,16 +161,19 @@ body {
 #memory-table {
     font-family: Courier New, Courier, monospace;
     margin: auto;
+    background-color: white;
 }
 
 #memory-table th {
     text-align: center;
     vertical-align: middle;
+    background-color: white;
 }
 
 #memory-table td {
     text-align: center;
     vertical-align: middle;
+    background-color: white;
 }
 
 #console-output {


### PR DESCRIPTION
Issue:
Machine: Macbook Pro 2015
Browser: Chrome  94.0.4606.81

switching from dark theme to light theme results in only every other row of the memory table in the simulator tab becoming light. the rest stay dark so that you end up with alternating dark and light rows.

quick fix:
explicitly define background color as white for memory-table in venus.css